### PR TITLE
Fix directory filter to not include issue filepaths

### DIFF
--- a/browser/index.mjs
+++ b/browser/index.mjs
@@ -3,14 +3,19 @@ import search from "./search.mjs";
 import issues from "./issues.mjs";
 import state from "./state.mjs";
 
-const specialTokensRegex = /[@#\/]\w+/g;
-const specialTokens = Array.from(
-  new Set(
-    document
-      .querySelector(".issue-issues")
-      .textContent.match(specialTokensRegex),
-  ),
-);
+const specialTokens = (() => {
+  const directoryTokenRegex = /\/\w+(?=\/)/g;
+  const otherTokensRegex = /[@#]\w+/g;
+
+  const { textContent } = document.querySelector(".issue-issues");
+
+  return Array.from(
+    new Set([
+      ...textContent.match(directoryTokenRegex),
+      ...textContent.match(otherTokensRegex),
+    ]),
+  );
+})();
 
 const searchTokens = (query) => {
   return query

--- a/browser/issues.mjs
+++ b/browser/issues.mjs
@@ -8,7 +8,7 @@ function mapFocusable(elem, cb) {
   }
 }
 
-export default function search(onState) {
+export default function issues(onState) {
   const issues = Array.from(document.getElementsByClassName("issue-issue"));
   const index = issues.map((issue) => [issue, issue.textContent]);
 

--- a/issue/open/__fix_directory_filter_to_not_include_issue_filepaths.md
+++ b/issue/open/__fix_directory_filter_to_not_include_issue_filepaths.md
@@ -1,0 +1,4 @@
+# Fix directory filter to not include issue filepaths
+
+The `/<directory>` should only work on directories and should not find issue
+filenames.


### PR DESCRIPTION
Fixes the issue where filepaths are included in the `/` filter:

![2023-12-10-142339_790x507_scrot](https://github.com/bas080/issue/assets/1840380/b01cf5a9-d0e0-4caf-8f04-ae76841ca232)
