### PR TITLE
CI: Cache OPAM files during build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,13 @@ jobs:
       - run: npm test
         working-directory: browser
 
+      - name: Cache OPAM
+        uses: actions/cache@v3
+        with:
+          path: ~/.opam
+          key: ${{ runner.os }}-opam-${{ matrix.ocaml-compiler }}-${{ hashFiles('**/*.opam') }}
+          restore-keys: ${{ runner.os }}-opam-${{ matrix.ocaml-compiler }}-
+
       - name: Setup OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2
         with:


### PR DESCRIPTION
This is only for a dev/test build. We will rebuild completely when a release build is required.